### PR TITLE
move nginx config for signoz frontend

### DIFF
--- a/signoz/docker-compose-minimal.yaml
+++ b/signoz/docker-compose-minimal.yaml
@@ -210,7 +210,7 @@ services:
     ports:
       - "3301:3301"
     volumes:
-      - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
+      - ./nginx-config.conf:/etc/nginx/conf.d/default.conf
 
   otel-collector-migrator:
     image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.102.10}

--- a/signoz/nginx-config.conf
+++ b/signoz/nginx-config.conf
@@ -1,0 +1,64 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen       3301;
+    server_name  _;
+
+    gzip on;
+    gzip_static on;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_proxied  any;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+
+    # to handle uri issue 414 from nginx
+    client_max_body_size 24M;
+    large_client_header_buffers 8 128k;
+
+    location / {
+        if ( $uri = '/index.html' ) {
+            add_header Cache-Control no-store always;
+        }
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~ ^/api/(v1|v3)/logs/(tail|livetail){
+        proxy_pass http://query-service:8080;
+        proxy_http_version 1.1;
+
+        # connection will be closed if no data is read for 600s between successive read operations
+        proxy_read_timeout 600s;
+
+        # dont buffer the data send it directly to client.
+        proxy_buffering off;
+        proxy_cache off;
+    }
+
+    location /api {
+        proxy_pass http://query-service:8080/api;
+        # connection will be closed if no data is read for 600s between successive read operations
+        proxy_read_timeout 600s; 
+    }
+
+    location /ws {
+        proxy_pass  http://query-service:8080/ws;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade "websocket";
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
the common folder was a misnomer. The config belonged with the otel collector config in the signoz folder